### PR TITLE
Added debian11 to test and meta files.

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -34,6 +34,8 @@ jobs:
           - image: "ubuntu1804"
           - image: "ubuntu2004"
           - image: "debian10"
+          - image: "debian11"
+          - image: "rockylinux8"
           
     steps:
       - name: checkout

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -35,7 +35,6 @@ jobs:
           - image: "ubuntu2004"
           - image: "debian10"
           - image: "debian11"
-          - image: "rockylinux8"
           
     steps:
       - name: checkout

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 galaxy_info:
   role_name: codium
+  namespace: greenleader
   author: Sion Fandrick
   description: Install Codium, a community-driven, freely-licensed binary distribution of Microsoft’s editor VSCode.
 
@@ -40,6 +41,7 @@ galaxy_info:
   - name: Debian
     versions:
     - buster
+    - bullseye
 
   galaxy_tags:
     - editor


### PR DESCRIPTION
Now debian11 - bullseye is listed as a supported OS. Should resolve #2 